### PR TITLE
Add an Install All option to Install NSP menu

### DIFF
--- a/include/ui/ui_installnsp_mode.hpp
+++ b/include/ui/ui_installnsp_mode.hpp
@@ -12,6 +12,8 @@ namespace tin::ui
             std::string m_name;
             FsStorageId m_destStorageId = FsStorageId_SdCard;
             bool m_ignoreReqFirmVersion = false;
+            std::vector<std::string> GetNSPList();
+            std::vector<std::string> nspList;
 
         public:
             InstallNSPMode();

--- a/include/ui/ui_installnsp_mode.hpp
+++ b/include/ui/ui_installnsp_mode.hpp
@@ -12,8 +12,8 @@ namespace tin::ui
             std::string m_name;
             FsStorageId m_destStorageId = FsStorageId_SdCard;
             bool m_ignoreReqFirmVersion = false;
-            std::vector<std::string> GetNSPList();
-            std::vector<std::string> nspList;
+            std::vector<std::string> m_nspList;
+            void GetNSPList();
 
         public:
             InstallNSPMode();

--- a/source/install/install_nsp.cpp
+++ b/source/install/install_nsp.cpp
@@ -151,8 +151,6 @@ namespace tin::install::nsp
         {
             printf("WARNING: Ticket installation failed! This may not be an issue, depending on your usecase.\nProceed with caution!\n");
         }
-
-        printf("Done!\n\nPress (B) to return.\n");
     }
 
     void NSPInstallTask::InstallNCA(const NcmNcaId &ncaId)

--- a/source/ui/ui_installextracted_mode.cpp
+++ b/source/ui/ui_installextracted_mode.cpp
@@ -137,5 +137,7 @@ namespace tin::ui
             LOG_DEBUG("%s", e.what());
             fprintf(stdout, "%s", e.what());
         }
+        
+        printf("Done!\n\nPress (B) to return.\n");
     }
 }

--- a/source/ui/ui_installnsp_mode.cpp
+++ b/source/ui/ui_installnsp_mode.cpp
@@ -14,10 +14,8 @@ namespace tin::ui
 
     }
 
-    std::vector<std::string> InstallNSPMode::GetNSPList()
+    void InstallNSPMode::GetNSPList()
     {
-        std::vector<std::string> nspList;
-
         nx::fs::IFileSystem fileSystem;
         fileSystem.OpenSdFileSystem();
         nx::fs::IDirectory dir = fileSystem.OpenDirectory("/tinfoil/nsp/", FS_DIROPEN_FILE);
@@ -37,9 +35,8 @@ namespace tin::ui
             if (dirEntry.type != ENTRYTYPE_FILE || dirEntryName.compare(dirEntryName.size() - ext.size(), ext.size(), ext) != 0)
                 continue;
 
-            nspList.push_back(dirEntry.name);
+            m_nspList.push_back(dirEntry.name);
         }
-        return nspList;
     }
 
     void InstallNSPMode::OnSelected()
@@ -49,15 +46,15 @@ namespace tin::ui
         view->AddEntry("Select NSP", tin::ui::ConsoleEntrySelectType::HEADING, nullptr);
         view->AddEntry("", tin::ui::ConsoleEntrySelectType::NONE, nullptr);
 
-        nspList = GetNSPList();
+        GetNSPList();
 
-        if (nspList.size() > 0)
+        if (m_nspList.size() > 0)
         {
             view->AddEntry("Install All", ConsoleEntrySelectType::SELECT, std::bind(&InstallNSPMode::OnNSPSelected, this));
 
-            for (unsigned int i = 0; i < nspList.size(); i++)
+            for (unsigned int i = 0; i < m_nspList.size(); i++)
             {
-                view->AddEntry(nspList[i], ConsoleEntrySelectType::SELECT, std::bind(&InstallNSPMode::OnNSPSelected, this));
+                view->AddEntry(m_nspList[i], ConsoleEntrySelectType::SELECT, std::bind(&InstallNSPMode::OnNSPSelected, this));
             }
         }
 
@@ -130,8 +127,7 @@ namespace tin::ui
 
         if (m_name == "Install All")
         {
-            // installList = GetNSPList();
-            installList = nspList;
+            installList = m_nspList;
         }
         else
         {

--- a/source/ui/ui_installnsp_mode.cpp
+++ b/source/ui/ui_installnsp_mode.cpp
@@ -46,7 +46,8 @@ namespace tin::ui
         view->AddEntry("Select NSP", tin::ui::ConsoleEntrySelectType::HEADING, nullptr);
         view->AddEntry("", tin::ui::ConsoleEntrySelectType::NONE, nullptr);
 
-        GetNSPList();
+        m_nspList.clear();
+        this->GetNSPList();
 
         if (m_nspList.size() > 0)
         {

--- a/source/ui/ui_installnsp_mode.cpp
+++ b/source/ui/ui_installnsp_mode.cpp
@@ -9,14 +9,14 @@
 namespace tin::ui
 {
     InstallNSPMode::InstallNSPMode() :
-    IMode("Install NSP")
+        IMode("Install NSP")
     {
 
     }
 
-    std::vector<std::string> GetNSPList()
+    std::vector<std::string> InstallNSPMode::GetNSPList()
     {
-        std::vector<std::string> nsp_list;
+        std::vector<std::string> nspList;
 
         nx::fs::IFileSystem fileSystem;
         fileSystem.OpenSdFileSystem();
@@ -28,7 +28,8 @@ namespace tin::ui
 
         dir.Read(0, dirEntries.get(), entryCount);
 
-        for (unsigned int i = 0; i < entryCount; i++) {
+        for (unsigned int i = 0; i < entryCount; i++)
+        {
             FsDirectoryEntry dirEntry = dirEntries[i];
             std::string dirEntryName(dirEntry.name);
             std::string ext = ".nsp";
@@ -36,9 +37,9 @@ namespace tin::ui
             if (dirEntry.type != ENTRYTYPE_FILE || dirEntryName.compare(dirEntryName.size() - ext.size(), ext.size(), ext) != 0)
                 continue;
 
-            nsp_list.push_back(dirEntry.name);
+            nspList.push_back(dirEntry.name);
         }
-        return nsp_list;
+        return nspList;
     }
 
     void InstallNSPMode::OnSelected()
@@ -48,7 +49,7 @@ namespace tin::ui
         view->AddEntry("Select NSP", tin::ui::ConsoleEntrySelectType::HEADING, nullptr);
         view->AddEntry("", tin::ui::ConsoleEntrySelectType::NONE, nullptr);
 
-        std::vector<std::string> nspList = GetNSPList();
+        nspList = GetNSPList();
 
         if (nspList.size() > 0)
         {
@@ -125,25 +126,26 @@ namespace tin::ui
 
         auto optStr = prevView->GetSelectedOptionValue()->GetText();
         m_ignoreReqFirmVersion = (optStr == "Yes");
-        std::vector<std::string> install_list;
+        std::vector<std::string> installList;
 
         if (m_name == "Install All")
         {
-            install_list = GetNSPList();
+            // installList = GetNSPList();
+            installList = nspList;
         }
         else
         {
-            install_list.push_back(m_name);
+            installList.push_back(m_name);
         }
 
         // Push a blank view ready for installation
         auto view = std::make_unique<tin::ui::ConsoleView>(3);
         manager.PushView(std::move(view));
 
-        for (unsigned int i = 0; i < install_list.size(); i++)
+        for (unsigned int i = 0; i < installList.size(); i++)
         {
-            printf("Installing %i/%ld\n", (i + 1), install_list.size());
-            std::string path = "@Sdcard://tinfoil/nsp/" + install_list[i];
+            printf("Installing %i/%ld\n", (i + 1), installList.size());
+            std::string path = "@Sdcard://tinfoil/nsp/" + installList[i];
 
             try
             {

--- a/source/ui/ui_installnsp_mode.cpp
+++ b/source/ui/ui_installnsp_mode.cpp
@@ -133,7 +133,7 @@ namespace tin::ui
         }
         else
         {
-            install_list[0] = m_name;
+            install_list.push_back(m_name);
         }
 
         // Push a blank view ready for installation

--- a/source/ui/ui_installnsp_mode.cpp
+++ b/source/ui/ui_installnsp_mode.cpp
@@ -172,7 +172,10 @@ namespace tin::ui
                 LOG_DEBUG("Failed to install NSP");
                 LOG_DEBUG("%s", e.what());
                 fprintf(stdout, "%s", e.what());
+                break;
             }
         }
+        
+        printf("Done!\n\nPress (B) to return.\n");
     }
 }


### PR DESCRIPTION
Heyo!

A lot of people were asking for this, so I decided to make a patch.

This patch is sort of big one, and makes some big changes around the `ui_installnsp_mode.cpp` file to allow batch installs. It also modifies the `InstallNSP()` function and removes the `Done! Press (B) to go back` notification as when you do a batch install, it's incorrect and can result in titledb and exfat corruptions if user backs out at the wrong moment. I instead moved that line to `installnsp` and `installextracted` ui files. Right now this PR doesn't allow batch installation of extracted NSPs (because I don't have any extracted NSPs lying around).

It also moves the function for getting NSPs from MicroSD to a new function (I was reading all entries on SD when `Install All` was triggered, which led to code repetition). ~~Let me know if you want me to move that function to a different file, or if you have a way of accessing old directory listing from the new function (I'm not great with C++).~~

Edit 3: I set the function as private and also managed to carry the first `nspList` over to the install function, reducing calls to that function from 2 to 1.

I personally tested it and it works fine with `install all` and on regular single installs.

It currently installs the NSPs in alphabetic order but I believe that order doesn't really matter as long as you end up installing base game. Let me know if I'm wrong.

Edit: oh and it breaks the for loop whenever an install error happens.

Edit 2: closes #15 

---

Link to built binaries: https://elixi.re/i/xow7.zip