### PR TITLE
Update buildservnx URL to the new one

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ DISCLAIMER: I take zero responsibility for any bans, damage, nuclear explosions,
 2. Place the tinfoil nro in the "switch" folder on your sd card, and run using the homebrew menu.
 
 ## Download
-Courtesy of [LavaTech](https://discord.gg/VjyDSuu), builds are made automatically for each commit at:
-https://buildserv.stayathomeserver.club/tinfoil/
+Courtesy of [LavaTech](https://discord.gg/VjyDSuu), builds are made automatically for each commit at:      
+https://bsnx.lavatech.top/tinfoil
 
-When ready, full releases will be located at:
+When ready, full releases will be located at:      
 https://github.com/Adubbz/Tinfoil/releases/latest
 
 ## Donate


### PR DESCRIPTION
So I bought a new domain for lavatech (as the other one was extremely long) and updated URLs on jenkins and bsnx config (old ones still work and probably will keep working for quite some while).

This PR simply changes the bsnx URL to the new one.

Also I took the liberty to put the URLs on different lines as that seems like the thing you intended to do. For future reference, it's just a matter of adding 6 spaces (because markdown is weird and quirky).