### PR TITLE
Accept CFLAGS and CXXFLAGS env vars

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,11 +57,11 @@ endif
 ARCH	:=	-march=armv8-a -mtune=cortex-a57 -mtp=soft -fPIE
 
 CFLAGS	:=	-g -Wall -O2 -ffunction-sections \
-			$(ARCH) $(DEFINES) 
+			$(ARCH) $(DEFINES) $(CFLAGS)
 
 CFLAGS	+=	$(INCLUDE) -D__SWITCH__
 
-CXXFLAGS	:= $(CFLAGS) -std=gnu++17
+CXXFLAGS	:= $(CFLAGS) -std=gnu++17 $(CXXFLAGS)
 
 ASFLAGS	:=	-g $(ARCH)
 LDFLAGS	=	-specs=$(DEVKITPRO)/libnx/switch.specs -g $(ARCH) -Wl,-Map,$(notdir $*.map)


### PR DESCRIPTION
Change the Makefile so environment CFLAGS/CXXFLAGS are accepted.
Reasoning: I have a custom includes folder. With this small modification, I don't have to edit the Makefile and can instead just do:
```$ CFLAGS="-I/home/neonsea/cust_includes" make```

Otherwise, behavior is the same as before.