### PR TITLE
Add too-low-firmware info to error 0x236e02

### DIFF
--- a/source/nx/fs.cpp
+++ b/source/nx/fs.cpp
@@ -97,7 +97,7 @@ namespace nx::fs
         rc = fsOpenFileSystemWithId(&m_fileSystem, titleId, fileSystemType, path.c_str());
 
         if (rc == 0x236e02)
-            errorMsg = "File " + path + " is corrupt! You may have a bad dump, or fs_mitm may need to be removed.";
+            errorMsg = "File " + path + " is unreadable! You may have a bad dump, fs_mitm may need to be removed, or your firmware version may be too low to decrypt.";
 
         ASSERT_OK(rc, errorMsg.c_str());
     }


### PR DESCRIPTION
In the future we could add support for NCA header key from keyfile to decrypt header and get actual firmware version requirement