### PR TITLE
fixed ncm content meta-database resource leak

### DIFF
--- a/source/install/install.cpp
+++ b/source/install/install.cpp
@@ -36,6 +36,8 @@ namespace tin::install
             serviceClose(&contentMetaDatabase.s);
             throw e;
         }
+		
+        serviceClose(&contentMetaDatabase.s);
     }
 
     void Install::InstallApplicationRecord()


### PR DESCRIPTION
fixed ncm content meta-database resource leak that would crash the switch after 24 installs.